### PR TITLE
Updates `find_examples` to support alternate docstring style.

### DIFF
--- a/example/test_example.py
+++ b/example/test_example.py
@@ -32,3 +32,15 @@ def test_python_self(example: CodeExample, eval_example: EvalExample):
     """
     eval_example.lint(example)
     eval_example.run_print_check(example)
+
+
+@pytest.mark.parametrize('example', find_examples('example/test_example.py'), ids=str)
+def test_python_self_change_docstyle(example: CodeExample, eval_example: EvalExample):
+    """Test this code (no line break at beginning of docstring).
+    ```py
+    print('this is introspection!')
+    #> this is introspection!
+    ```
+    """
+    eval_example.lint(example)
+    eval_example.run_print_check(example)

--- a/pytest_examples/find_examples.py
+++ b/pytest_examples/find_examples.py
@@ -140,7 +140,7 @@ def find_examples(*paths: str | Path, skip: bool = False) -> Iterable[CodeExampl
             group = uuid4()
             if path.suffix == '.py':
                 code = path.read_text('utf-8')
-                for m_docstring in re.finditer(r'(^ *)(r?"""[^\r\n]*\n)(.+?)\1"""', code, flags=re.M | re.S):
+                for m_docstring in re.finditer(r'(^ *)(r?""".*?\n)(.+?)\1"""', code, flags=re.M | re.S):
                     start_line = code[: m_docstring.start()].count('\n') + 1
                     docstring = m_docstring.group(3)
                     index_offset = m_docstring.start() + len(m_docstring.group(1)) + len(m_docstring.group(2))

--- a/pytest_examples/find_examples.py
+++ b/pytest_examples/find_examples.py
@@ -140,7 +140,7 @@ def find_examples(*paths: str | Path, skip: bool = False) -> Iterable[CodeExampl
             group = uuid4()
             if path.suffix == '.py':
                 code = path.read_text('utf-8')
-                for m_docstring in re.finditer(r'(^ *)(r?"""\n)(.+?)\1"""', code, flags=re.M | re.S):
+                for m_docstring in re.finditer(r'(^ *)(r?"""[^\r\n]*\n)(.+?)\1"""', code, flags=re.M | re.S):
                     start_line = code[: m_docstring.start()].count('\n') + 1
                     docstring = m_docstring.group(3)
                     index_offset = m_docstring.start() + len(m_docstring.group(1)) + len(m_docstring.group(2))

--- a/tests/test_find_examples.py
+++ b/tests/test_find_examples.py
@@ -92,6 +92,15 @@ def func_b():
     ```
     """
     pass
+
+def func_c():
+    """Does cool things.
+    ```py
+    g = 7
+    h = 8
+    assert g + h == 15
+    ```
+    """
         ''',
     )
     pytester.makepyfile(
@@ -107,12 +116,13 @@ def test_find_examples(example):
     )
 
     result = pytester.runpytest('-p', 'no:pretty', '-vs')
-    result.assert_outcomes(passed=3)
+    result.assert_outcomes(passed=4)
 
     output = '\n'.join(result.outlines)
     assert 'test_find_examples[my_file.py:3-7] PASSED' in output
     assert 'test_find_examples[my_file.py:14-18] PASSED' in output
     assert 'test_find_examples[my_file.py:20-24] PASSED' in output
+    assert 'test_find_examples[my_file.py:30-34] PASSED' in output
 
 
 def test_find_file_example(pytester: pytest.Pytester):


### PR DESCRIPTION
Adds support for docstrings without a line break directly after the triple quotes.

I found this plugin and wanted to use it for my own projects but noticed an issue with example discovery when the docstrings have text on the first line following the initial triple quotes like this:

```python
def func():
    """Does some things.
    ```py
    assert True
    ```
    """
```

This PR updates the regex in `find_examples` to capture this style of docstring as well as the original. Included updates to tests to capture the change.