### PR TITLE
Remove the behavior of removing the double line breaks in python files

### DIFF
--- a/pytest_examples/eval_example.py
+++ b/pytest_examples/eval_example.py
@@ -217,7 +217,7 @@ class EvalExample:
         """
         self._check_update(example)
 
-        new_content = black_format(example.source, self.config, remove_double_blank=example.in_py_file())
+        new_content = black_format(example.source, self.config)
         if new_content != example.source:
             example.source = new_content
             self._mark_for_update(example)

--- a/pytest_examples/lint.py
+++ b/pytest_examples/lint.py
@@ -65,19 +65,17 @@ def ruff_check(
         return stdout
 
 
-def black_format(source: str, config: ExamplesConfig, *, remove_double_blank: bool = False) -> str:
+def black_format(source: str, config: ExamplesConfig) -> str:
     # hack to avoid black complaining about our print output format
     before_black = re.sub(r'^( *#)> ', r'\1 > ', source, flags=re.M)
     after_black = black_format_str(before_black, mode=config.black_mode())
     # then revert it back
     after_black = re.sub(r'^( *#) > ', r'\1> ', after_black, flags=re.M)
-    if remove_double_blank:
-        after_black = re.sub(r'\n{3}', '\n\n', after_black)
     return after_black
 
 
 def black_check(example: CodeExample, config: ExamplesConfig) -> None:
-    after_black = black_format(example.source, config, remove_double_blank=example.in_py_file())
+    after_black = black_format(example.source, config)
     if example.source != after_black:
         diff = code_diff(example, after_black)
         raise FormatError(f'black failed:\n{indent(diff, "  ")}')

--- a/tests/cases_update/python_class.py
+++ b/tests/cases_update/python_class.py
@@ -16,8 +16,10 @@ def foobar():
     ```py
     x = 4
 
+
     class A:
         pass
+
 
     print(x)
     #> 4


### PR DESCRIPTION
I see the benefits of removing double line breaks in the docstrings, but this has caused a bunch of pain getting ruff and black to both format and check without errors, @adriangb and I both feel this would make things simpler enough to be worth the change.

In particular, right now in pydantic if you run the formatting code, you get double line breaks that need to be removed, but I struggled to make it work where it would remove those and also not fail black/ruff checks.

Definitely open to a fix on the pydantic side, I just don't know that it's worth the brain power given the only benefit is removing (currently in pydantic) a single newline from one docstring each in three files.

If there was broader usage of this library I'd be more concerned but my understanding is that we are probably the only ones using it very deeply for this purpose, and I suspect no one would mind the change.