### PR TITLE
Reenable double-newline-removal for python files properly

### DIFF
--- a/pytest_examples/eval_example.py
+++ b/pytest_examples/eval_example.py
@@ -206,8 +206,8 @@ class EvalExample:
 
         :param example: The example to format.
         """
-        self.format_black(example)
         self.format_ruff(example)
+        self.format_black(example)
 
     def format_black(self, example: CodeExample) -> None:
         """
@@ -217,7 +217,7 @@ class EvalExample:
         """
         self._check_update(example)
 
-        new_content = black_format(example.source, self.config)
+        new_content = black_format(example.source, self.config, remove_double_blank=example.in_py_file())
         if new_content != example.source:
             example.source = new_content
             self._mark_for_update(example)

--- a/pytest_examples/lint.py
+++ b/pytest_examples/lint.py
@@ -65,17 +65,19 @@ def ruff_check(
         return stdout
 
 
-def black_format(source: str, config: ExamplesConfig) -> str:
+def black_format(source: str, config: ExamplesConfig, *, remove_double_blank: bool = False) -> str:
     # hack to avoid black complaining about our print output format
     before_black = re.sub(r'^( *#)> ', r'\1 > ', source, flags=re.M)
     after_black = black_format_str(before_black, mode=config.black_mode())
     # then revert it back
     after_black = re.sub(r'^( *#) > ', r'\1> ', after_black, flags=re.M)
+    if remove_double_blank:
+        after_black = re.sub(r'\n{3}', '\n\n', after_black)
     return after_black
 
 
 def black_check(example: CodeExample, config: ExamplesConfig) -> None:
-    after_black = black_format(example.source, config)
+    after_black = black_format(example.source, config, remove_double_blank=example.in_py_file())
     if example.source != after_black:
         diff = code_diff(example, after_black)
         raise FormatError(f'black failed:\n{indent(diff, "  ")}')

--- a/tests/cases_update/python_class.py
+++ b/tests/cases_update/python_class.py
@@ -16,10 +16,8 @@ def foobar():
     ```py
     x = 4
 
-
     class A:
         pass
-
 
     print(x)
     #> 4


### PR DESCRIPTION
This is the diff relative to the commit _before_ the latest commit on main.
```diff
diff --git a/pytest_examples/eval_example.py b/pytest_examples/eval_example.py
index ddedbb4..aebe106 100644
--- a/pytest_examples/eval_example.py
+++ b/pytest_examples/eval_example.py
@@ -206,8 +206,8 @@ class EvalExample:
 
         :param example: The example to format.
         """
-        self.format_black(example)
         self.format_ruff(example)
+        self.format_black(example)
 
     def format_black(self, example: CodeExample) -> None:
         """
```
So this is mostly just reverting the previous change, but changing the order here ensures that we don't get wrong reformatting when removing the double newline from python files. (I tested this in pydantic and it seems all doc tests work after running `pytest --update-examples`)