### PR TITLE
Fix a bug in the handling of single line docstrings

### DIFF
--- a/pytest_examples/find_examples.py
+++ b/pytest_examples/find_examples.py
@@ -140,8 +140,8 @@ def find_examples(*paths: str | Path, skip: bool = False) -> Iterable[CodeExampl
             group = uuid4()
             if path.suffix == '.py':
                 code = path.read_text('utf-8')
-                for m_docstring in re.finditer(r'(^ *)(r?""".*?\n)(.+?)\1"""', code, flags=re.M | re.S):
-                    start_line = code[: m_docstring.start()].count('\n') + 1
+                for m_docstring in re.finditer(r'(^ *)(r?""")(.+?)\1"""', code, flags=re.M | re.S):
+                    start_line = code[: m_docstring.start()].count('\n')
                     docstring = m_docstring.group(3)
                     index_offset = m_docstring.start() + len(m_docstring.group(1)) + len(m_docstring.group(2))
                     yield from _extract_code_chunks(


### PR DESCRIPTION
This fixes a bug where single-line docstrings would cause it to think the start of the next docstring was the end of the single line docstring, resulting in it looking in code for examples and not looking in the actual docstrings for examples.