### PR TITLE
Use tb_lineno to point to correct line in traceback

### DIFF
--- a/pytest_examples/traceback.py
+++ b/pytest_examples/traceback.py
@@ -36,12 +36,10 @@ def create_example_traceback(exc: Exception, module_path: str, example: CodeExam
 
 def create_custom_frame(frame: FrameType, example: CodeExample) -> FrameType:
     """
-    Create a new frame that mostly matches `frame` but with a filename from `example` and line number
-    altered to match the example.
+    Create a new frame that mostly matches `frame` but with a filename from `example`.
 
     Taken mostly from https://naleraphael.github.io/blog/posts/devlog_create_a_builtin_frame_object/
-    With the CodeType creation inspired by https://stackoverflow.com/a/16123158/949890. However, we use
-    `frame.f_lineno` for the line number instead of `f_code.co_firstlineno` as that seems to work.
+    With the CodeType creation inspired by https://stackoverflow.com/a/16123158/949890.
     """
     import ctypes
 
@@ -77,7 +75,7 @@ def create_custom_frame(frame: FrameType, example: CodeExample) -> FrameType:
             str(example.path),
             f_code.co_name,
             f_code.co_qualname,
-            frame.f_lineno + example.start_line,
+            f_code.co_firstlineno,
             f_code.co_lnotab,
             f_code.co_exceptiontable,
         )
@@ -95,7 +93,7 @@ def create_custom_frame(frame: FrameType, example: CodeExample) -> FrameType:
             f_code.co_varnames,
             str(example.path),
             f_code.co_name,
-            frame.f_lineno + example.start_line,
+            f_code.co_firstlineno,
             f_code.co_lnotab,
         )
 

--- a/pytest_examples/traceback.py
+++ b/pytest_examples/traceback.py
@@ -36,7 +36,9 @@ def create_example_traceback(exc: Exception, module_path: str, example: CodeExam
 
 def create_custom_frame(frame: FrameType, example: CodeExample) -> FrameType:
     """
-    Create a new frame that mostly matches `frame` but with a filename from `example`.
+    Create a new frame that mostly matches `frame` but with a code object that has
+    a filename from `example` and adjusted an adjusted first line number
+    so that pytest shows the correct code context in the traceback.
 
     Taken mostly from https://naleraphael.github.io/blog/posts/devlog_create_a_builtin_frame_object/
     With the CodeType creation inspired by https://stackoverflow.com/a/16123158/949890.
@@ -75,7 +77,7 @@ def create_custom_frame(frame: FrameType, example: CodeExample) -> FrameType:
             str(example.path),
             f_code.co_name,
             f_code.co_qualname,
-            f_code.co_firstlineno,
+            f_code.co_firstlineno + example.start_line,
             f_code.co_lnotab,
             f_code.co_exceptiontable,
         )
@@ -93,7 +95,7 @@ def create_custom_frame(frame: FrameType, example: CodeExample) -> FrameType:
             f_code.co_varnames,
             str(example.path),
             f_code.co_name,
-            f_code.co_firstlineno,
+            f_code.co_firstlineno + example.start_line,
             f_code.co_lnotab,
         )
 

--- a/pytest_examples/traceback.py
+++ b/pytest_examples/traceback.py
@@ -1,7 +1,6 @@
 from __future__ import annotations as _annotations
 
 import sys
-import traceback
 from types import CodeType, FrameType, TracebackType
 from typing import TYPE_CHECKING
 
@@ -21,16 +20,17 @@ def create_example_traceback(exc: Exception, module_path: str, example: CodeExam
         # f_code.co_posonlyargcount was added in 3.8
         return None
     frames = []
-    for frame, _ in traceback.walk_tb(exc.__traceback__):
+    tb = exc.__traceback__
+    while tb is not None:
+        frame = tb.tb_frame
         if frame.f_code.co_filename == module_path:
-            frames.append(create_custom_frame(frame, example))
+            frames.append((create_custom_frame(frame, example), tb.tb_lasti, tb.tb_lineno + example.start_line))
+        tb = tb.tb_next
 
     frames.reverse()
     new_tb = None
-    for altered_frame in frames:
-        new_tb = TracebackType(
-            tb_next=new_tb, tb_frame=altered_frame, tb_lasti=altered_frame.f_lasti, tb_lineno=altered_frame.f_lineno
-        )
+    for altered_frame, lasti, lineno in frames:
+        new_tb = TracebackType(tb_next=new_tb, tb_frame=altered_frame, tb_lasti=lasti, tb_lineno=lineno)
     return new_tb
 
 

--- a/tests/test_run_examples.py
+++ b/tests/test_run_examples.py
@@ -52,8 +52,8 @@ def test_find_run_examples(example: CodeExample, eval_example: EvalExample):
     result = pytester.runpytest('-p', 'no:pretty', '-v')
     result.assert_outcomes(passed=1, failed=1)
 
-    assert result.outlines[-11:-3] == [
-        '_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ ',
+    assert result.outlines[-11].startswith('_ _ _ _ ')
+    assert result.outlines[-10:-3] == [
         '',
         '    a = 1',
         '    b = 2',

--- a/tests/test_run_examples.py
+++ b/tests/test_run_examples.py
@@ -54,7 +54,7 @@ def test_find_run_examples(example: CodeExample, eval_example: EvalExample):
 
     # assert 'my_file_9_13.py:12: AssertionError' in '\n'.join(result.outlines)
     assert result.outlines[-8:-3] == [
-        '',
+        '    b = 2',
         '>   assert a + b == 4',
         'E   AssertionError',
         '',

--- a/tests/test_run_examples.py
+++ b/tests/test_run_examples.py
@@ -52,8 +52,10 @@ def test_find_run_examples(example: CodeExample, eval_example: EvalExample):
     result = pytester.runpytest('-p', 'no:pretty', '-v')
     result.assert_outcomes(passed=1, failed=1)
 
-    # assert 'my_file_9_13.py:12: AssertionError' in '\n'.join(result.outlines)
-    assert result.outlines[-8:-3] == [
+    assert result.outlines[-11:-3] == [
+        '_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ ',
+        '',
+        '    a = 1',
         '    b = 2',
         '>   assert a + b == 4',
         'E   AssertionError',

--- a/tests/test_run_examples.py
+++ b/tests/test_run_examples.py
@@ -224,7 +224,10 @@ def test_run_directly(tmp_path, eval_example):
 x = 4
 
 def div(y):
-    return x / y
+    try:
+        return x / y
+    finally:
+        str(y)
 
 div(2)
 div(0)"""
@@ -244,10 +247,10 @@ div(0)"""
 
     # debug(exc_info.traceback)
     assert exc_info.traceback[-1].frame.code.path == md_file
-    assert exc_info.traceback[-1].lineno == 6
+    assert exc_info.traceback[-1].lineno == 7
 
     assert exc_info.traceback[-2].frame.code.path == md_file
-    assert exc_info.traceback[-2].lineno == 9
+    assert exc_info.traceback[-2].lineno == 12
 
 
 def test_print_sub(pytester: pytest.Pytester):


### PR DESCRIPTION
Tracebacks should generally use `tb_lineno/lasti` instead of `f_lineno/lasti`. From https://docs.python.org/3/reference/datamodel.html#traceback-objects:

> tb_lineno gives the line number where the exception occurred; tb_lasti indicates the precise instruction. The line number and last instruction in the traceback may differ from the line number of its frame object if the exception occurred in a [try](https://docs.python.org/3/reference/compound_stmts.html#try) statement with no matching except clause or with a finally clause.

