### PR TITLE
`ruff` now requires the `check` specification

### DIFF
--- a/pytest_examples/lint.py
+++ b/pytest_examples/lint.py
@@ -48,7 +48,7 @@ def ruff_check(
     extra_ruff_args: tuple[str, ...] = (),
 ) -> str:
     args = 'ruff', 'check', '-', *config.ruff_config(), *extra_ruff_args
-    
+
     p = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     stdout, stderr = p.communicate(example.source, timeout=2)
     if p.returncode == 1 and stdout:

--- a/pytest_examples/lint.py
+++ b/pytest_examples/lint.py
@@ -47,8 +47,8 @@ def ruff_check(
     *,
     extra_ruff_args: tuple[str, ...] = (),
 ) -> str:
-    args = 'ruff', '-', *config.ruff_config(), *extra_ruff_args
-
+    args = 'ruff', 'check', '-', *config.ruff_config(), *extra_ruff_args
+    
     p = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     stdout, stderr = p.communicate(example.source, timeout=2)
     if p.returncode == 1 and stdout:


### PR DESCRIPTION
Add `check` to the ruff command call, tested locally with `pydantic` and all tests are passing.