### PR TITLE
lint: raise timeout to avoid flakyness

### DIFF
--- a/pytest_examples/lint.py
+++ b/pytest_examples/lint.py
@@ -50,7 +50,7 @@ def ruff_check(
     args = 'ruff', 'check', '-', *config.ruff_config(), *extra_ruff_args
 
     p = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-    stdout, stderr = p.communicate(example.source, timeout=2)
+    stdout, stderr = p.communicate(example.source, timeout=10)
     if p.returncode == 1 and stdout:
 
         def replace_offset(m: re.Match):


### PR DESCRIPTION
A two seconds timeout makes the test suite a bit flaky on heavily loaded build machines.

This commit raises the timeout to 10 seconds to give a bit more headroom to the scheduler.