### PR TITLE
lint: use python helper to point to the ruff bin

### DIFF
--- a/pytest_examples/lint.py
+++ b/pytest_examples/lint.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from black import format_str as black_format_str
 from black.output import diff as black_diff
+from ruff.__main__ import find_ruff_bin
 
 from .config import ExamplesConfig
 
@@ -47,7 +48,8 @@ def ruff_check(
     *,
     extra_ruff_args: tuple[str, ...] = (),
 ) -> str:
-    args = 'ruff', 'check', '-', *config.ruff_config(), *extra_ruff_args
+    ruff = find_ruff_bin()
+    args = ruff, 'check', '-', *config.ruff_config(), *extra_ruff_args
 
     p = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     stdout, stderr = p.communicate(example.source, timeout=10)


### PR DESCRIPTION
`ruff` may not be in the `PATH` for consumer of this library, The python helper is here to point to the correct place.

This is especially true on NixOS.