### PR TITLE
Allow matching prefix with curly braces in `CodeExample.prefix_settings()`

### DIFF
--- a/pytest_examples/find_examples.py
+++ b/pytest_examples/find_examples.py
@@ -76,7 +76,7 @@ class CodeExample:
         This works on the format `py foo="bar" spam="with space"`.
         """
         settings = {}
-        for m in re.finditer(r'(\S+?)=([\'"])(.+?)\2', self.prefix):
+        for m in re.finditer(r'([^{\s]+?)=([\'"])(.+?)\2', self.prefix):
             settings[m.group(1)] = m.group(3)
         return settings
 


### PR DESCRIPTION
The SuperFences markdown extensions uses the following format for attributes: `lang-name {.extra-class attr="a"}`

See: https://facelessuser.github.io/pymdown-extensions/extensions/superfences/#injecting-classes-ids-and-attributes