### PR TITLE
Ensure `print_callback` runs before formatting print args

### DIFF
--- a/pytest_examples/run_code.py
+++ b/pytest_examples/run_code.py
@@ -212,9 +212,8 @@ class InsertPrintStatements:
     def _insert_print_args(
         self, lines: list[str], statement: PrintStatement, in_python: bool, line_index: int, col: int
     ) -> None:
-        single_line = statement.sep.join(map(str, statement.args))
-        if self.print_callback:
-            single_line = self.print_callback(single_line)
+        formatted_args = [self.print_callback(str(arg)) if self.print_callback else str(arg) for arg in statement.args]
+        single_line = statement.sep.join(formatted_args)
         indent_str = ' ' * col
         max_single_length = self.config.line_length - len(indent_str)
         if '\n' not in single_line and len(single_line) + len(comment_prefix) < max_single_length:


### PR DESCRIPTION
## Description

This pull request addresses the issue where the `print_callback` needs to be executed before formatting print arguments. Currently, the issue arises as `repr()` generates output that is not valid code, causing a break in the black formatting of the output.

## Changes Made
- Added a pre-execution step for `print_callback` to ensure it runs before formatting print arguments. This helps prevent `repr()` from creating output that breaks the black formatting of the output.

## How to Test
1. Ensure the `print_callback` is triggered before formatting print arguments.
2. Verify that the black formatting of the output is not disrupted by invalid code generated by `repr()`.

## Related Issue
[Link to the original issue](link-to-issue)

## Additional Notes
Any additional information or context about the changes made can be added here.

This is a necessary adjustment to maintain proper formatting integrity and prevent issues caused by invalid code generated during execution.