### PR TITLE
feat: Make windows-compatible

### DIFF
--- a/pytest_examples/config.py
+++ b/pytest_examples/config.py
@@ -29,6 +29,8 @@ class ExamplesConfig:
     ruff_ignore: list[str] | None = None
     white_space_dot: bool = False
     """If True, replace spaces with `·` in example diffs."""
+    encoding: str | None = 'utf-8'
+    """File encoding to use for write file operations. Default is 'utf-8'."""
 
     def black_mode(self):
         return BlackMode(

--- a/pytest_examples/config.py
+++ b/pytest_examples/config.py
@@ -29,8 +29,6 @@ class ExamplesConfig:
     ruff_ignore: list[str] | None = None
     white_space_dot: bool = False
     """If True, replace spaces with `·` in example diffs."""
-    encoding: str | None = 'utf-8'
-    """File encoding to use for write file operations. Default is 'utf-8'."""
 
     def black_mode(self):
         return BlackMode(

--- a/pytest_examples/eval_example.py
+++ b/pytest_examples/eval_example.py
@@ -43,6 +43,7 @@ class EvalExample:
         ruff_line_length: int | None = None,
         ruff_select: list[str] | None = None,
         ruff_ignore: list[str] | None = None,
+        encoding: str | None = 'utf-8',
     ):
         """Set the config for lints.
 
@@ -56,6 +57,7 @@ class EvalExample:
             ruff_line_length: In general, we disable line-length checks in ruff, to let black take care of them.
             ruff_select: Ruff rules to select
             ruff_ignore: Ruff rules to ignore
+            encoding: File encoding to use for write file operations, defaults to 'utf-8'.
         """
         self.config = ExamplesConfig(
             line_length=line_length,
@@ -67,6 +69,7 @@ class EvalExample:
             ruff_line_length=ruff_line_length,
             ruff_select=ruff_select,
             ruff_ignore=ruff_ignore,
+            encoding=encoding,
         )
 
     @property
@@ -269,5 +272,5 @@ class EvalExample:
 
     def _write_file(self, example: CodeExample) -> Path:
         python_file = self.tmp_path / f'{example.module_name}.py'
-        python_file.write_text(example.source)
+        python_file.write_text(example.source, encoding=self.config.encoding)
         return python_file

--- a/pytest_examples/eval_example.py
+++ b/pytest_examples/eval_example.py
@@ -43,7 +43,6 @@ class EvalExample:
         ruff_line_length: int | None = None,
         ruff_select: list[str] | None = None,
         ruff_ignore: list[str] | None = None,
-        encoding: str | None = 'utf-8',
     ):
         """Set the config for lints.
 
@@ -57,7 +56,6 @@ class EvalExample:
             ruff_line_length: In general, we disable line-length checks in ruff, to let black take care of them.
             ruff_select: Ruff rules to select
             ruff_ignore: Ruff rules to ignore
-            encoding: File encoding to use for write file operations, defaults to 'utf-8'.
         """
         self.config = ExamplesConfig(
             line_length=line_length,
@@ -69,7 +67,6 @@ class EvalExample:
             ruff_line_length=ruff_line_length,
             ruff_select=ruff_select,
             ruff_ignore=ruff_ignore,
-            encoding=encoding,
         )
 
     @property
@@ -272,5 +269,5 @@ class EvalExample:
 
     def _write_file(self, example: CodeExample) -> Path:
         python_file = self.tmp_path / f'{example.module_name}.py'
-        python_file.write_text(example.source, encoding=self.config.encoding)
+        python_file.write_text(example.source, encoding='utf-8')
         return python_file

--- a/pytest_examples/lint.py
+++ b/pytest_examples/lint.py
@@ -51,7 +51,7 @@ def ruff_check(
     ruff = find_ruff_bin()
     args = ruff, 'check', '-', *config.ruff_config(), *extra_ruff_args
 
-    p = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    p = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE, encoding=config.encoding)
     stdout, stderr = p.communicate(example.source, timeout=10)
     if p.returncode == 1 and stdout:
 

--- a/pytest_examples/lint.py
+++ b/pytest_examples/lint.py
@@ -51,7 +51,7 @@ def ruff_check(
     ruff = find_ruff_bin()
     args = ruff, 'check', '-', *config.ruff_config(), *extra_ruff_args
 
-    p = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE, encoding=config.encoding)
+    p = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE, encoding='utf-8')
     stdout, stderr = p.communicate(example.source, timeout=10)
     if p.returncode == 1 and stdout:
 

--- a/pytest_examples/modify_files.py
+++ b/pytest_examples/modify_files.py
@@ -45,6 +45,6 @@ def _modify_files(examples: list[CodeExample]) -> str:
             count += 1
 
         msg.append(f'  {path} {count} examples updated')
-        path.write_text(content)
+        path.write_text(content, encoding='utf-8')
 
     return '\n'.join(msg)

--- a/pytest_examples/modify_files.py
+++ b/pytest_examples/modify_files.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from .find_examples import CodeExample
 
 
-def _modify_files(examples: list[CodeExample]) -> str:
+def _modify_files(examples: list[CodeExample], encoding: str | None = 'utf-8') -> str:
     """Internal use only, update examples in place."""
     # The same example shouldn't appear more than once
     unique_examples: set[str] = set()
@@ -34,7 +34,7 @@ def _modify_files(examples: list[CodeExample]) -> str:
     msg = [f'pytest-examples: {len(examples)} examples to update in {len(files)} file(s)...']
 
     for path, g in groupby(examples, key=lambda ex: ex.path):
-        content = path.read_text()
+        content = path.read_text(encoding=encoding)
         count = 0
         for ex in g:
             example: CodeExample = ex
@@ -45,6 +45,6 @@ def _modify_files(examples: list[CodeExample]) -> str:
             count += 1
 
         msg.append(f'  {path} {count} examples updated')
-        path.write_text(content, encoding='utf-8')
+        path.write_text(content, encoding=encoding)
 
     return '\n'.join(msg)

--- a/pytest_examples/modify_files.py
+++ b/pytest_examples/modify_files.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from .find_examples import CodeExample
 
 
-def _modify_files(examples: list[CodeExample], encoding: str | None = 'utf-8') -> str:
+def _modify_files(examples: list[CodeExample]) -> str:
     """Internal use only, update examples in place."""
     # The same example shouldn't appear more than once
     unique_examples: set[str] = set()
@@ -34,7 +34,7 @@ def _modify_files(examples: list[CodeExample], encoding: str | None = 'utf-8') -
     msg = [f'pytest-examples: {len(examples)} examples to update in {len(files)} file(s)...']
 
     for path, g in groupby(examples, key=lambda ex: ex.path):
-        content = path.read_text(encoding=encoding)
+        content = path.read_text(encoding='utf-8')
         count = 0
         for ex in g:
             example: CodeExample = ex
@@ -45,6 +45,6 @@ def _modify_files(examples: list[CodeExample], encoding: str | None = 'utf-8') -
             count += 1
 
         msg.append(f'  {path} {count} examples updated')
-        path.write_text(content, encoding=encoding)
+        path.write_text(content, encoding='utf-8')
 
     return '\n'.join(msg)

--- a/tests/test_run_examples.py
+++ b/tests/test_run_examples.py
@@ -370,3 +370,23 @@ def test_find_run_examples(example: CodeExample, eval_example: EvalExample):
 
     result = pytester.runpytest('-p', 'no:pretty', '-v')
     result.assert_outcomes(passed=1)
+
+
+def test_unicode_emoji(pytester: pytest.Pytester):
+    pytester.makefile(
+        '.md',
+        my_file="```py\nprint('🚀 ✓')\n#> 🚀 ✓\n```",
+    )
+    pytester.makepyfile(
+        """
+from pytest_examples import find_examples, CodeExample, EvalExample
+import pytest
+
+@pytest.mark.parametrize('example', find_examples('.'), ids=str)
+def test_find_run_examples(example: CodeExample, eval_example: EvalExample):
+    eval_example.run_print_check(example)
+"""
+    )
+
+    result = pytester.runpytest('-p', 'no:pretty', '-v')
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
## Summary
Hey here!
Thank you very much for the library, it is really useful and helpful

This PR fixes how `pytest-examples` works on Windows with sane (`utf-8`) default

### Motivation
I'm using `pytest-examples` library in a small library I will release, and noticed that on Windows I get errors when try to run tests in docs with emojis
Windows has a thing where if you don't specify encoding, the default regional encoding is used, which is never `utf-8`

### Traceback in my project, where I use `pytest-examples` with current code:
```
FAILED tests/test_docs.py::test_docs_examples[docs\\lax.md:9-22] - UnicodeEncodeError: 'charmap' codec can't encode character '\u2713' in position 237: character maps to <undefined>
```

### Result of a test I have added in this PR with current code:
```
self = <encodings.cp1252.IncrementalEncoder object at 0x0000023B17AF9BB0>
input = "print('🚀 ✓')\r\n#> 🚀 ✓\r\n", final = False

    def encode(self, input, final=False):
>       return codecs.charmap_encode(input,self.errors,encoding_table)[0]
E       UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f680' in position 7: character maps to <undefined>

..\..\..\..\..\Roaming\uv\python\cpython-3.14.0-windows-x86_64-none\Lib\encodings\cp1252.py:19: UnicodeEncodeError
```
