### PR TITLE
Fix ruff 0.16 compatibility (pin default rule set + concise output)

### DIFF
--- a/pytest_examples/config.py
+++ b/pytest_examples/config.py
@@ -44,7 +44,10 @@ class ExamplesConfig:
 
     def ruff_config(self) -> tuple[str, ...]:
         config_lines: list[str] = []
-        select: list[str] = []
+        # Pin ruff's classic default rule set as our base rather than inheriting ruff's evolving defaults:
+        # ruff 0.16 added `I` (isort) and `FA` (future-annotations) to the defaults, which would silently
+        # start flagging examples that pytest-examples never opted into. Opt-in flags extend this base.
+        select: list[str] = ['E4', 'E7', 'E9', 'F']
         ignore: list[str] = []
         args: list[str] = []
 
@@ -76,8 +79,7 @@ class ExamplesConfig:
             ignore.extend(self.ruff_ignore)
 
         if select:
-            # use extend to not disable default select
-            args.append(f'--extend-select={",".join(select)}')
+            args.append(f'--select={",".join(select)}')
         if ignore:
             args.append(f'--ignore={",".join(ignore)}')
 

--- a/pytest_examples/lint.py
+++ b/pytest_examples/lint.py
@@ -49,7 +49,9 @@ def ruff_check(
     extra_ruff_args: tuple[str, ...] = (),
 ) -> str:
     ruff = find_ruff_bin()
-    args = ruff, 'check', '-', *config.ruff_config(), *extra_ruff_args
+    # Pin the concise output format: ruff 0.16 made the grouped `full` format the default, which breaks the
+    # `^-:(\d+)` offset rewriting below and the readable one-line-per-error output.
+    args = ruff, 'check', '-', '--output-format=concise', *config.ruff_config(), *extra_ruff_args
 
     p = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE, encoding='utf-8')
     stdout, stderr = p.communicate(example.source, timeout=10)


### PR DESCRIPTION
Fixes #69.

Ruff 0.16 broke `test_ruff_ok`, `test_ruff_error`, and `test_ruff_config` with two independent changes:

1. **New rules in the default set.** Ruff 0.16 promoted `I` (isort) and `FA` (flake8-future-annotations) into its default rule selection. Since `ruff_config()` used `--extend-select` on top of ruff's defaults, examples suddenly got `I001` / `FA100` that pytest-examples never opted into (import sorting is opt-in via `isort=`, and there's no future-annotations option at all).

   Fix: pin ruff's classic default base (`E4,E7,E9,F`) explicitly and use `--select`, so the enforced rule set no longer drifts with ruff's defaults. Opt-in flags (`isort`, `upgrade`, `quotes`, `ruff_select`) extend this base exactly as before. This reproduces the pre-0.16 behavior, so the existing test assertions pass unchanged.

2. **Default output format changed.** Ruff 0.16 made the grouped `full` format the default, which breaks the `^-:(\d+)` offset rewriting in `ruff_check` and the readable one-error-per-line output. Fix: pass `--output-format=concise` explicitly.

`tests/test_lint.py` and the ruff/isort/upgrade cases in `tests/test_run_examples.py` are green.

Out of scope: a few `test_black_*` / `test_insert_print` cases and `test_update_examples_dir.py` also fail on `main`, but those are due to a newer **black**/pytest, not ruff — happy to tackle them separately if useful.
