### PR TITLE
Fix the ruff include glob so example/ is actually linted

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,10 @@ xfail_strict = true
 [tool.ruff]
 line-length = 120
 target-version = "py39"
-include = ["pytest_examples/**/*.py", "tests/**/*.py", "examples/**/*.py"]
-exclude = ["tests/cases_update/*.py"]
+include = ["pytest_examples/**/*.py", "tests/**/*.py", "example/**/*.py"]
+# `example/test_example.py` is its own test data: it demonstrates the `#>` print marker, which
+#  `docstring-code-format` rewrites to `# >`, and two docstring styles that `D212` would collapse.
+exclude = ["tests/cases_update/*.py", "example/test_example.py"]
 
 [tool.ruff.lint]
 extend-select = ["Q", "RUF100", "C90", "UP", "I", "D"]


### PR DESCRIPTION
## What

Point the ruff `include` glob at `example/`, and add `example/test_example.py` to `exclude`.

## Why

The glob names `examples/`, but the directory is `example/`, so it has never matched anything and the example package the suite runs against is not linted at all.

That file is the one thing under `example/` that cannot be linted or formatted, because it is its own test data: `find_examples` parses its docstrings. `docstring-code-format` rewrites the `#>` print markers inside them to `# >`, and `D212` would collapse the two docstring styles that `test_python_self_change_docstyle` exists to cover. It joins `tests/cases_update/*.py` in `exclude`, which already holds test data for the same reason.

## How to test

`make lint` passes and leaves `example/test_example.py` untouched. Add any other `.py` file under `example/` and `ruff check` now reports it.
