### PR TITLE
Let requires-python set the ruff target version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ xfail_strict = true
 
 [tool.ruff]
 line-length = 120
-target-version = "py39"
 include = ["pytest_examples/**/*.py", "tests/**/*.py", "examples/**/*.py"]
 exclude = ["tests/cases_update/*.py"]
 

--- a/pytest_examples/run_code.py
+++ b/pytest_examples/run_code.py
@@ -358,12 +358,12 @@ def expr_last_line(c: ast.expr) -> int:
             return maybe_plus_1(c, expr_last_line(c.args[-1]))
         else:
             return c.lineno
-    elif isinstance(c, (ast.List, ast.Tuple, ast.Set)):
+    elif isinstance(c, ast.List | ast.Tuple | ast.Set):
         if c.elts:
             return maybe_plus_1(c, expr_last_line(c.elts[-1]))
         else:
             return c.lineno
-    elif isinstance(c, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+    elif isinstance(c, ast.ListComp | ast.SetComp | ast.DictComp | ast.GeneratorExp):
         gen = c.generators[-1]
         if gen.ifs:
             return maybe_plus_1(c, expr_last_line(gen.ifs[-1]))


### PR DESCRIPTION
## What

Delete `target-version = "py39"` from `[tool.ruff]`, and rewrite the two `isinstance` calls that the raised target flags.

## Why

`requires-python` is `>=3.10`, so ruff was linting the package against a floor two releases below the one it declares.

Deleting the key rather than updating it means it cannot drift again: when `target-version` is absent, ruff reads the floor from `requires-python`.

The higher target surfaces two `UP038` findings in `run_code.py`. Both are rewritten to the `X | Y` form, which `isinstance` has accepted since 3.10.

## How to test

`make lint`, `make typecheck` and the test suite. No behaviour change.
